### PR TITLE
Don't use transactions to read the data

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "yarn build && yarn lint && yarn test",
-    "build": "rm -rf dist tsc --declaration",
+    "build": "rm -rf dist && tsc --declaration",
     "publish:docs": "typedoc --options typedoc.json",
     "lint": "eslint 'src/**/*.ts'",
     "test": "yarn build && nyc mocha -r ts-node/register -r tslib -r source-map-support/register --full-trace src/__tests__/**/*.test.ts --timeout 5000"

--- a/src/GraphQLQueryManager.ts
+++ b/src/GraphQLQueryManager.ts
@@ -161,7 +161,7 @@ export class GraphQLQueryManager {
     const queue = this._queue.splice(0, this._queue.length);
     try {
       return await this._connection.transaction(async entityManager => {
-        queue.map(this._resolveQueueItem(entityManager));
+        await Promise.all(queue.map(this._resolveQueueItem(entityManager)));
       });
     } catch (e) {
       queue.forEach(q => {

--- a/src/GraphQLQueryManager.ts
+++ b/src/GraphQLQueryManager.ts
@@ -159,7 +159,7 @@ export class GraphQLQueryManager {
   private async _processQueue(): Promise<any> {
     // Clear and capture the current queue
     const queue = this._queue.splice(0, this._queue.length);
-    const queryRunner = this._connection.createQueryRunner('slave')
+    const queryRunner = this._connection.createQueryRunner('slave');
 
     try {
       await queryRunner.connect();
@@ -171,7 +171,7 @@ export class GraphQLQueryManager {
       });
     }
 
-    await queryRunner.release()
+    await queryRunner.release();
   }
 
   /**


### PR DESCRIPTION
Hi Bryan,
I'm following up on my issue on Gitlab: https://gitlab.com/Mando75/typeorm-graphql-loader/-/issues/12.
I don't have Gitlab keys set-up, sorry ;(

This PR changes GraphQLQueryManager, so it longer uses transactions for reading data, and also delegates reading to the replicas whenever they're available (that is default Typeorm behaviour when you use `.find({})`). This PR is still requires testing in the live projects, but I think there would be no breaking changes. It's passing all the tests though.

Cheers,